### PR TITLE
specify subpackages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
     author="Ben Money-Coomes",
     author_email="ben.money@gmail.com",
     url="https://github.com/meisben",
-    packages=["cri_dobot",],
+    packages=["cri_dobot","cri_dobot.dobotMagician"],
     install_requires=["numpy", "transforms3d"]
 )


### PR DESCRIPTION
Needed when installing package automatically (I.e. as a dependency when installing tactip_toolkit_dobot, which downloads this repo straight from github)